### PR TITLE
feat : 공통컴포넌트 네비게이션 제작

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,3 +1,4 @@
+import BottomNavigation from '~/components/common/bottom-nav';
 import Button from '~/components/common/button';
 import {
   Card,
@@ -53,6 +54,10 @@ const Home = () => {
             <Button size="full">참여하기</Button>
           </CardFooter>
         </Card>
+      </div>
+      <div>
+        <p>nav</p>
+        <BottomNavigation />
       </div>
     </div>
   );

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,9 +14,9 @@
         "next": "15.1.7",
         "react": "^19.0.0",
         "react-dom": "^19.0.0",
+        "react-hook-form": "^7.54.2",
         "react-icons": "^5.5.0",
         "tailwind-merge": "^3.0.2",
-        "react-hook-form": "^7.54.2",
         "zod": "^3.24.2"
       },
       "devDependencies": {
@@ -5609,15 +5609,6 @@
         "react": "^19.0.0"
       }
     },
-    "node_modules/react-icons": {
-      "version": "5.5.0",
-      "resolved": "https://registry.npmjs.org/react-icons/-/react-icons-5.5.0.tgz",
-      "integrity": "sha512-MEFcXdkP3dLo8uumGI5xN3lDFNsRtrjbOEKDLD7yv76v4wpnEq2Lt2qeHaQOr34I/wPN3s3+N08WkQ+CW37Xiw==",
-      "license": "MIT",
-      "peerDependencies": {
-        "react": "*"
-      }
-    },
     "node_modules/react-hook-form": {
       "version": "7.54.2",
       "resolved": "https://registry.npmjs.org/react-hook-form/-/react-hook-form-7.54.2.tgz",
@@ -5632,6 +5623,15 @@
       },
       "peerDependencies": {
         "react": "^16.8.0 || ^17 || ^18 || ^19"
+      }
+    },
+    "node_modules/react-icons": {
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/react-icons/-/react-icons-5.5.0.tgz",
+      "integrity": "sha512-MEFcXdkP3dLo8uumGI5xN3lDFNsRtrjbOEKDLD7yv76v4wpnEq2Lt2qeHaQOr34I/wPN3s3+N08WkQ+CW37Xiw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "*"
       }
     },
     "node_modules/react-is": {

--- a/src/components/common/bottom-nav.tsx
+++ b/src/components/common/bottom-nav.tsx
@@ -1,0 +1,54 @@
+'use client';
+import { cva, type VariantProps } from 'class-variance-authority';
+import { cn } from '~/utils/cn';
+import Link from 'next/link';
+import { usePathname } from 'next/navigation';
+
+const bottomNavLinkVariants = cva(
+  'flex items-center justify-center p-4 text-sm font-medium',
+  {
+    variants: {
+      variant: {
+        default: 'text-gray-500',
+        active: 'text-blue-500 border-t-2 border-blue-500',
+      },
+    },
+    defaultVariants: {
+      variant: 'default',
+    },
+  },
+);
+
+interface BottomNavLinkProps
+  extends VariantProps<typeof bottomNavLinkVariants> {
+  to: string;
+  label: string;
+}
+
+const BottomNavLink = ({ to, label }: BottomNavLinkProps) => {
+  const pathname = usePathname(); // 현재 경로 가져오기
+  const isActive = pathname === to; // 활성 상태 확인
+
+  return (
+    <Link
+      href={to}
+      className={cn(
+        bottomNavLinkVariants({ variant: isActive ? 'active' : 'default' }),
+      )}
+    >
+      {label}
+    </Link>
+  );
+};
+
+const BottomNavigation = () => {
+  return (
+    <nav className="fixed bottom-0 left-0 right-0 flex justify-around bg-white border-t border-gray-200">
+      <BottomNavLink to="/" label="홈" />
+      <BottomNavLink to="/notifications" label="알림" />
+      <BottomNavLink to="/mypage" label="마이페이지" />
+    </nav>
+  );
+};
+
+export default BottomNavigation;

--- a/src/components/common/chat-bubble.tsx
+++ b/src/components/common/chat-bubble.tsx
@@ -50,10 +50,18 @@ const ChatBubble = ({
         {message}
       </div>
       {variant === 'sender' && (
-        <div className="absolute bottom-0 right-0 w-2 h-2 bg-blue-500 transform translate-x-1/2 translate-y-1/2 rotate-45"></div>
+        <div
+          className="absolute bottom-0 right-0 w-0 h-0 translate-y-2
+    border-t-[15px] border-t-blue-500 
+    border-l-[15px] border-l-transparent"
+        ></div>
       )}
       {variant === 'receiver' && (
-        <div className="absolute bottom-0 left-0 w-2 h-2 bg-gray-200 transform -translate-x-1/2 translate-y-1/2 rotate-45"></div>
+        <div
+          className="absolute bottom-0 left-0 w-0 h-0 translate-y-2
+    border-t-[15px] border-t-gray-200 
+    border-r-[15px] border-r-transparent"
+        ></div>
       )}
     </div>
   );

--- a/src/components/common/modalOneBtn.tsx
+++ b/src/components/common/modalOneBtn.tsx
@@ -55,7 +55,9 @@ const ModalOneBtn = ({
           <IoCloseSharp onClick={btnCloseHandler} className="cursor-pointer" />
         </div>
         <p className="mb-10">{text}</p>
-        <Button size={'full'} onClick={btnCloseHandler}>{textBtn}</Button>
+        <Button size={'full'} onClick={btnCloseHandler}>
+          {textBtn}
+        </Button>
       </div>
     )
   );

--- a/src/components/common/modalTwoBtn.tsx
+++ b/src/components/common/modalTwoBtn.tsx
@@ -34,9 +34,9 @@ interface ModalTwoBtnProps
   textRBtn?: string;
 }
 
-interface ButtonProps extends React.HTMLAttributes<HTMLButtonElement>{
-  textLBtn?:string;
-  textRBtn?:string; 
+interface ButtonProps extends React.HTMLAttributes<HTMLButtonElement> {
+  textLBtn?: string;
+  textRBtn?: string;
 }
 
 const ModalTwoBtn = ({
@@ -63,8 +63,12 @@ const ModalTwoBtn = ({
         </div>
         <p className="mb-10 text-center">{text}</p>
         <div>
-          <Button size={'full'} onClick={btnCloseHandler}>{textLBtn}</Button>
-          <Button size={'full'} onClick={btnCloseHandler}>{textRBtn}</Button>
+          <Button size={'full'} onClick={btnCloseHandler}>
+            {textLBtn}
+          </Button>
+          <Button size={'full'} onClick={btnCloseHandler}>
+            {textRBtn}
+          </Button>
         </div>
       </div>
     )


### PR DESCRIPTION
## 📌 관련 이슈

> #13 

## 📑 작업 내용

- 공통컴포넌트 하단 네비게이션을 적용했습니다.
- usePathname() 사용했습니다.
- 클라이언트 컴포넌트로 동작하여 'use client'를 추가하였습니다.

## 🖥️ (Optional) 참고자료

- 스크린샷이나 참고사항을 넣어주세요, 없으실 경우 생략 가능합니다.
![스크린샷 2025-03-05 09 46 01](https://github.com/user-attachments/assets/ddf41a02-c461-428b-9ba5-d89b5b4ee89e)
