### PR TITLE
Feat: 그룹 매칭 현상태 바 컴포넌트 생성

### DIFF
--- a/src/components/match/match-card.tsx
+++ b/src/components/match/match-card.tsx
@@ -12,7 +12,7 @@ interface MatchCardProps {
   inMyPage?: boolean;
   bgOnChipInterest?: boolean;
   bgOnChipPurpose?: boolean;
-  group?: boolean; 
+  group?: boolean;
 }
 
 const MatchCard = ({ userData, inMyPage, group = false }: MatchCardProps) => {
@@ -52,7 +52,7 @@ const MatchCard = ({ userData, inMyPage, group = false }: MatchCardProps) => {
             )}
           </div>
         </div>
-        {group && <StatusForGroup variants="available" /> }
+        {group && <StatusForGroup variants="available" />}
       </CardBody>
     </Card>
   );

--- a/src/components/match/match-card.tsx
+++ b/src/components/match/match-card.tsx
@@ -5,15 +5,17 @@ import { Card, CardBody } from '../common/card';
 import BadgesAligned from '../common/badges-aligned';
 import Button from '../common/button';
 import { IoIosBookmark } from 'react-icons/io';
+import StatusForGroup from './status-for-group';
 
 interface MatchCardProps {
   userData: UserData;
   inMyPage?: boolean;
   bgOnChipInterest?: boolean;
   bgOnChipPurpose?: boolean;
+  group?: boolean; 
 }
 
-const MatchCard = ({ userData, inMyPage }: MatchCardProps) => {
+const MatchCard = ({ userData, inMyPage, group = false }: MatchCardProps) => {
   // Data for the profile card
 
   return (
@@ -50,6 +52,7 @@ const MatchCard = ({ userData, inMyPage }: MatchCardProps) => {
             )}
           </div>
         </div>
+        {group && <StatusForGroup variants="available" /> }
       </CardBody>
     </Card>
   );

--- a/src/components/match/status-for-group.tsx
+++ b/src/components/match/status-for-group.tsx
@@ -1,0 +1,30 @@
+
+const circleColorMapping: Record<string, string> = {
+    available: 'bg-[#07ca7f]',
+    networking: 'bg-[#ff5050]',
+    joined: 'bg-[#ff9257]',
+  };
+  
+
+  const statusLabels: Record<string, string> = {
+    available: '참여 가능',
+    networking: '네트워킹 진행중',
+    joined: '참여중',
+  };
+
+interface StatusForGroupProps {
+    variants: string; 
+    className?: string; 
+}
+
+
+const StatusForGroup = ({ variants, className }: StatusForGroupProps) => {
+return (
+// <div className="w-full relative rounded-radius-8 bg-gray-900 flex flex-row items-center justify-start py-spacing-8 px-spacing-12 box-border gap-spacing-6 text-left text-xs text-white font-body5-normal-b-12">
+<div className={`w-full relative rounded-2xl bg-gray-900 flex flex-row items-center justify-start py-2 px-4 box-border gap-2 text-left text-xs text-white font-body5-normal-b-12 mt-2 ${className}`}>
+  <div className={`w-2 relative rounded-[50%] bg-green-500 h-2 ${circleColorMapping[variants]} `} />
+  <div className="flex flex-row items-center justify-start"></div>
+  <div className="relative tracking-[-0.02em] leading-[140%] font-semibold">{statusLabels[variants]}</div>
+</div>);
+};
+export default StatusForGroup;

--- a/src/components/match/status-for-group.tsx
+++ b/src/components/match/status-for-group.tsx
@@ -1,30 +1,34 @@
-
 const circleColorMapping: Record<string, string> = {
-    available: 'bg-[#07ca7f]',
-    networking: 'bg-[#ff5050]',
-    joined: 'bg-[#ff9257]',
-  };
-  
+  available: 'bg-[#07ca7f]',
+  networking: 'bg-[#ff5050]',
+  joined: 'bg-[#ff9257]',
+};
 
-  const statusLabels: Record<string, string> = {
-    available: '참여 가능',
-    networking: '네트워킹 진행중',
-    joined: '참여중',
-  };
+const statusLabels: Record<string, string> = {
+  available: '참여 가능',
+  networking: '네트워킹 진행중',
+  joined: '참여중',
+};
 
 interface StatusForGroupProps {
-    variants: string; 
-    className?: string; 
+  variants: string;
+  className?: string;
 }
 
-
 const StatusForGroup = ({ variants, className }: StatusForGroupProps) => {
-return (
-// <div className="w-full relative rounded-radius-8 bg-gray-900 flex flex-row items-center justify-start py-spacing-8 px-spacing-12 box-border gap-spacing-6 text-left text-xs text-white font-body5-normal-b-12">
-<div className={`w-full relative rounded-2xl bg-gray-900 flex flex-row items-center justify-start py-2 px-4 box-border gap-2 text-left text-xs text-white font-body5-normal-b-12 mt-2 ${className}`}>
-  <div className={`w-2 relative rounded-[50%] bg-green-500 h-2 ${circleColorMapping[variants]} `} />
-  <div className="flex flex-row items-center justify-start"></div>
-  <div className="relative tracking-[-0.02em] leading-[140%] font-semibold">{statusLabels[variants]}</div>
-</div>);
+  return (
+    // <div className="w-full relative rounded-radius-8 bg-gray-900 flex flex-row items-center justify-start py-spacing-8 px-spacing-12 box-border gap-spacing-6 text-left text-xs text-white font-body5-normal-b-12">
+    <div
+      className={`w-full relative rounded-2xl bg-gray-900 flex flex-row items-center justify-start py-2 px-4 box-border gap-2 text-left text-xs text-white font-body5-normal-b-12 mt-2 ${className}`}
+    >
+      <div
+        className={`w-2 relative rounded-[50%] bg-green-500 h-2 ${circleColorMapping[variants]} `}
+      />
+      <div className="flex flex-row items-center justify-start"></div>
+      <div className="relative tracking-[-0.02em] leading-[140%] font-semibold">
+        {statusLabels[variants]}
+      </div>
+    </div>
+  );
 };
 export default StatusForGroup;


### PR DESCRIPTION
## 📌 관련 이슈

> 관련된 이슈를 태그해주세요 ex) #60 

## 📑 
- 그룹 매칭에 이용되는 현 상태 바 생성 
- variants 값에 따라 변동될  수 있게 하였음 (2번 이미지 참고)  
- matchCard의 재사용성을 위해 group일 때만 해당 컴포넌트가 뜨게 함 
- group의 기본 값은 false로 디폴트 값을 1:1매칭으로 둠 

## 🖥️ (Optional) 참고자료

##### 1번 이미지 
![image](https://github.com/user-attachments/assets/c4132ec8-4ee8-47a7-93e4-f121f26a2823)

##### 2번 이미지  
![image](https://github.com/user-attachments/assets/2bfc25e6-c449-4ca6-a715-4d277cd0533f)

