### PR TITLE
Feature/chacha 50

### DIFF
--- a/app/(main-layout)/create-group/page.tsx
+++ b/app/(main-layout)/create-group/page.tsx
@@ -1,0 +1,78 @@
+'use client';
+
+import { FormProvider, useForm } from 'react-hook-form';
+import Button from '~/components/common/button';
+import ToggleField from '~/components/register/toggle-field';
+import {
+  interestOptions,
+  jobOptions,
+  purposeOptions,
+} from '~/constants/create-group';
+import { careerOptions } from '~/constants/job-options';
+
+const Page = () => {
+  const methods = useForm<{
+    job: string[];
+    interest: string[];
+    career: string[];
+    purpose: string[];
+  }>({
+    defaultValues: {
+      job: [],
+      interest: [],
+      career: [],
+      purpose: [],
+    },
+  });
+
+  const { control, handleSubmit, watch } = methods;
+  const selectedOptions = watch();
+
+  return (
+    <div className="pt-[60px] pb-[100px] px-5">
+      <div className="flex flex-col gap-2 pt-5 pb-8">
+        <p className="text-heading-xs font-semibold">
+          이런 멤버를 만나고 싶어요
+        </p>
+        <p className="text-body-sm text-orange-500">
+          ⚠ 선택한 기준이 표시되지만, 꼭 일치하는 분만 들어오는 건 아니에요!
+        </p>
+      </div>
+      <FormProvider {...methods}>
+        <form>
+          <ToggleField
+            label="직무/직책"
+            name="job"
+            control={control}
+            options={jobOptions}
+          />
+          <ToggleField
+            label="관심분야"
+            name="interest"
+            control={control}
+            options={interestOptions}
+          />
+          <ToggleField
+            label="경력"
+            name="career"
+            control={control}
+            options={careerOptions}
+          />
+          <ToggleField
+            label="참여목적"
+            name="purpose"
+            control={control}
+            options={purposeOptions}
+          />
+
+          <div className="flex gap-4">
+            <Button>취소</Button>
+            <Button disabled={!selectedOptions}>만들기</Button>
+          </div>
+        </form>
+      </FormProvider>
+    </div>
+  );
+};
+
+export default Page;

--- a/app/(main-layout)/create-group/page.tsx
+++ b/app/(main-layout)/create-group/page.tsx
@@ -39,7 +39,7 @@ const Page = () => {
   return (
     <div className="pt-[60px] pb-[100px] px-5">
       <div className="flex flex-col gap-2 pt-5 pb-8">
-        <p className="text-heading-xs font-semibold">
+        <p className="text-heading-xs font-semibold text-white">
           이런 멤버를 만나고 싶어요
         </p>
         <p className="text-body-sm text-orange-500">

--- a/app/(main-layout)/create-group/page.tsx
+++ b/app/(main-layout)/create-group/page.tsx
@@ -65,9 +65,13 @@ const Page = () => {
             options={purposeOptions}
           />
 
-          <div className="flex gap-4">
-            <Button>취소</Button>
-            <Button disabled={!selectedOptions}>만들기</Button>
+          <div className="flex gap-2">
+            <Button size={'full'} variant={'black/50'}>
+              취소
+            </Button>
+            <Button size={'full'} disabled={!selectedOptions}>
+              만들기
+            </Button>
           </div>
         </form>
       </FormProvider>

--- a/app/(main-layout)/create-group/page.tsx
+++ b/app/(main-layout)/create-group/page.tsx
@@ -27,6 +27,14 @@ const Page = () => {
 
   const { control, handleSubmit, watch } = methods;
   const selectedOptions = watch();
+  const isValid = Object.values(selectedOptions).every(
+    (valueArr) => valueArr.length > 0,
+  );
+  const onSubmit = handleSubmit((data) => {
+    if (data) {
+      console.log(data);
+    }
+  });
 
   return (
     <div className="pt-[60px] pb-[100px] px-5">
@@ -39,7 +47,7 @@ const Page = () => {
         </p>
       </div>
       <FormProvider {...methods}>
-        <form>
+        <form onSubmit={onSubmit}>
           <ToggleField
             label="직무/직책"
             name="job"
@@ -69,7 +77,7 @@ const Page = () => {
             <Button size={'full'} variant={'black/50'}>
               취소
             </Button>
-            <Button size={'full'} disabled={!selectedOptions}>
+            <Button size={'full'} disabled={!isValid}>
               만들기
             </Button>
           </div>

--- a/src/components/common/button.tsx
+++ b/src/components/common/button.tsx
@@ -19,7 +19,7 @@ const buttonVariants = cva(
         sm: 'py-[6px] px-[10px] text-[13px]',
         md: 'py-[10px] px-[16px] text-[14px]',
         lg: 'py-[14px] px-[28px] text-[16px]',
-        full: 'w-full h-[50px]',
+        full: 'w-full h-[50px] text-[16px]',
       },
     },
     defaultVariants: {

--- a/src/components/common/radix-toggle-group.tsx
+++ b/src/components/common/radix-toggle-group.tsx
@@ -17,12 +17,14 @@ interface RadixToggleGroupProps<T extends FieldValues>
 }
 
 const itemsVariants = cva(
-  'py-1 h-[30px] px-4 flex items-center justify-center rounded-full whitespace-nowrap text-sm transition-colors focus-visible:outline-none disabled:pointer-events-none disabled:opacity-50',
+  'py-1 px-4 flex items-center justify-center rounded-full whitespace-nowrap text-sm transition-colors focus-visible:outline-none disabled:pointer-events-none disabled:opacity-50',
   {
     variants: {
       variant: {
         black:
           'data-[state=on]:bg-green-500 data-[state=on]:text-white bg-neutral-600 text-white border border-black',
+        primary:
+          'h-[40px] px-[18px] py-3 bg-gray-800/60 border border-gray-neutral-500/30 text-gray-neutral-400 data-[state=on]:bg-transparent data-[state=on]:border-green-500 data-[state=on]:text-green-500',
       },
     },
     defaultVariants: {

--- a/src/components/common/radix-toggle-group.tsx
+++ b/src/components/common/radix-toggle-group.tsx
@@ -2,16 +2,18 @@ import * as React from 'react';
 import { ToggleGroup } from 'radix-ui';
 import { cva, VariantProps } from 'class-variance-authority';
 import { cn } from '~/utils/cn';
+import { FieldValues, Path } from 'react-hook-form';
 
 interface ToggleItem {
   value: string;
 }
 
-interface RadixToggleGroupProps extends VariantProps<typeof itemsVariants> {
+interface RadixToggleGroupProps<T extends FieldValues>
+  extends VariantProps<typeof itemsVariants> {
   items: ToggleItem[];
   value: string[];
   ariaLabel: string;
-  onChange: (value: string[]) => void;
+  onChange: (newValue: T[Path<T>]) => void;
 }
 
 const itemsVariants = cva(
@@ -29,13 +31,13 @@ const itemsVariants = cva(
   },
 );
 
-const RadixToggleGroup = ({
+const RadixToggleGroup = <T extends FieldValues>({
   items,
   ariaLabel,
   variant,
   value,
   onChange,
-}: RadixToggleGroupProps) => (
+}: RadixToggleGroupProps<T>) => (
   <ToggleGroup.Root
     type="multiple"
     aria-label={ariaLabel}

--- a/src/components/common/top-nav.tsx
+++ b/src/components/common/top-nav.tsx
@@ -40,7 +40,19 @@ const TopNavigation = () => {
 
         {type === 'default' && (
           <>
-            <p className="text-lg font-semibold text-white">{title}</p>
+            <div className="flex gap-2">
+              {pathname === '/create-group' && (
+                <button onClick={() => router.back()}>
+                  <Image
+                    src="/assets/svgs/BackArrow.svg"
+                    alt="뒤로가기"
+                    width={24}
+                    height={24}
+                  />
+                </button>
+              )}
+              <p className="text-lg font-semibold text-white">{title}</p>
+            </div>
             <div className="flex gap-4">
               <div className="w-6 h-6 border border-dashed border-[#02e473]" />
               <div className="w-6 h-6 border border-dashed border-[#02e473]" />

--- a/src/components/register/interest-form.tsx
+++ b/src/components/register/interest-form.tsx
@@ -1,107 +1,52 @@
 'use client';
 
-import { Controller, useForm } from 'react-hook-form';
+import { useForm, FormProvider } from 'react-hook-form';
 import { interestOptions } from '~/constants/interest';
-import RadixToggleGroup from '../common/radix-toggle-group';
 import Button from '../common/button';
 import useFormSubmit from '~/utils/use-form-submit';
+import ToggleField from './toggle-field';
 
 const InterestForm = () => {
   const MIN_SELECTION = 1; // 최소 선택 개수
   const MAX_SELECTION = 2; // 최대 선택 개수
 
-  const MESSAGE = {
-    MIN_ERROR: `최소 ${MIN_SELECTION}개 이상 선택해야 합니다.`,
-    MAX_ERROR: `최대 ${MAX_SELECTION}개까지 선택 가능 합니다.`,
-  };
-
-  const {
-    control,
-    handleSubmit,
-    setValue,
-    setError,
-    clearErrors,
-    watch,
-    formState: { errors },
-  } = useForm<{ interest: string[] }>({
+  const methods = useForm<{
+    interest: string[];
+  }>({
     defaultValues: {
       interest: [],
     },
     mode: 'onChange',
   });
 
+  const { control, handleSubmit, watch } = methods;
+
   const onSubmit = handleSubmit(useFormSubmit('/'));
   const selectedOptions = watch('interest');
 
-  // 선택하지 않거나 n개 이상 선택할 경우 방지
-  const handleValueChange = (newValue: string[]) => {
-    clearErrors('interest');
-
-    if (newValue.length < MIN_SELECTION) {
-      setError('interest', {
-        type: 'manual',
-        message: `${MESSAGE.MIN_ERROR}`,
-      });
-    } else if (newValue.length > MAX_SELECTION) {
-      setError('interest', {
-        type: 'manual',
-        message: `${MESSAGE.MAX_ERROR}`,
-      });
-      return;
-    } else {
-      clearErrors('interest');
-    }
-
-    setValue('interest', newValue, { shouldValidate: true });
-  };
-
   return (
-    <div className="h-full">
-      <form
-        onSubmit={onSubmit}
-        className="flex flex-col justify-between h-full"
-      >
-        <div>
-          <Controller
+    <FormProvider {...methods}>
+      <div className="h-full">
+        <form
+          onSubmit={onSubmit}
+          className="flex flex-col justify-between h-full"
+        >
+          <ToggleField
             name="interest"
             control={control}
-            rules={{
-              validate: (value) => {
-                if (value.length < MIN_SELECTION) {
-                  return MESSAGE.MIN_ERROR;
-                }
-                if (value.length > MAX_SELECTION) {
-                  return MESSAGE.MAX_ERROR;
-                }
-                return true;
-              },
-            }}
-            render={() => (
-              <RadixToggleGroup
-                items={interestOptions}
-                value={selectedOptions}
-                onChange={handleValueChange}
-                ariaLabel="interest option"
-                variant={'black'}
-              />
-            )}
+            options={interestOptions}
+            minSelection={MIN_SELECTION}
+            maxSelection={MAX_SELECTION}
           />
-
-          {errors.interest && (
-            <p className="text-red-500 text-sm mt-2">
-              {errors.interest.message as string}
-            </p>
-          )}
-        </div>
-
-        <Button
-          className="py-3"
-          disabled={selectedOptions.length < MIN_SELECTION}
-        >
-          사전등록 완료!
-        </Button>
-      </form>
-    </div>
+          <Button
+            className="py-3"
+            disabled={selectedOptions.length < MIN_SELECTION}
+          >
+            사전등록 완료!
+          </Button>
+        </form>
+      </div>
+    </FormProvider>
   );
 };
 

--- a/src/components/register/toggle-field.tsx
+++ b/src/components/register/toggle-field.tsx
@@ -1,0 +1,85 @@
+import {
+  Control,
+  Controller,
+  FieldValues,
+  Path,
+  useFormContext,
+} from 'react-hook-form';
+import RadixToggleGroup from '../common/radix-toggle-group';
+
+interface ToggleFieldProps<T extends FieldValues> {
+  name: Path<T>;
+  control: Control<T>;
+  options: { category?: string; value: string }[];
+  label?: string;
+  rules?: string;
+  minSelection?: number;
+  maxSelection?: number;
+}
+
+const ToggleField = <T extends FieldValues>({
+  name,
+  control,
+  options,
+  label,
+  minSelection = 1,
+  maxSelection = 1,
+}: ToggleFieldProps<T>) => {
+  const { setError, setValue } = useFormContext();
+
+  return (
+    <div>
+      <p className="mb-1 font-medium text-sm text-gray-200">{label}</p>
+      <Controller
+        name={name}
+        control={control}
+        rules={{
+          validate: (value: string[]) => {
+            if (value.length < minSelection) {
+              return `최소 ${minSelection}개 이상 선택해야 합니다.`;
+            }
+            if (value.length > maxSelection) {
+              return `최대 ${maxSelection}개까지 선택 가능 합니다.`;
+            }
+            return true;
+          },
+        }}
+        render={({ field: { value }, fieldState: { error } }) => {
+          const handleValueChange = (newValue: T[typeof name]) => {
+            if (newValue.length < minSelection) {
+              setError(name, {
+                type: 'manual',
+                message: `최소 ${minSelection}개 이상 선택해야 합니다.`,
+              });
+            } else if (newValue.length > maxSelection) {
+              setError(name, {
+                type: 'manual',
+                message: `최대 ${maxSelection}개까지 선택 가능 합니다.`,
+              });
+              return;
+            }
+
+            setValue(name, newValue, { shouldValidate: true });
+          };
+
+          return (
+            <>
+              <RadixToggleGroup
+                items={options}
+                value={value}
+                onChange={handleValueChange}
+                ariaLabel={`${label} 옵션`}
+                variant={'black'}
+              />
+              {error && (
+                <p className="text-red-500 text-sm mt-2">{error.message}</p>
+              )}
+            </>
+          );
+        }}
+      />
+    </div>
+  );
+};
+
+export default ToggleField;

--- a/src/components/register/toggle-field.tsx
+++ b/src/components/register/toggle-field.tsx
@@ -28,8 +28,13 @@ const ToggleField = <T extends FieldValues>({
   const { setError, setValue } = useFormContext();
 
   return (
-    <div>
-      <p className="mb-1 font-medium text-sm text-gray-200">{label}</p>
+    <div className="mb-8">
+      <div className="flex gap-3 content-center">
+        <div className="w-6 h-6 border border-dashed border-[#02e473]" />
+        <p className="mb-4 font-bold text-body-lg text-gray-neutral-50">
+          {label}
+        </p>
+      </div>
       <Controller
         name={name}
         control={control}

--- a/src/components/register/toggle-field.tsx
+++ b/src/components/register/toggle-field.tsx
@@ -46,20 +46,32 @@ const ToggleField = <T extends FieldValues>({
         }}
         render={({ field: { value }, fieldState: { error } }) => {
           const handleValueChange = (newValue: T[typeof name]) => {
-            if (newValue.length < minSelection) {
-              setError(name, {
-                type: 'manual',
-                message: `최소 ${minSelection}개 이상 선택해야 합니다.`,
-              });
-            } else if (newValue.length > maxSelection) {
-              setError(name, {
-                type: 'manual',
-                message: `최대 ${maxSelection}개까지 선택 가능 합니다.`,
-              });
-              return;
+            let selectedValue: T[typeof name];
+
+            // 단일 선택
+            if (maxSelection === 1) {
+              const lastSelected = newValue.pop();
+              selectedValue = (
+                lastSelected ? [lastSelected] : []
+              ) as T[typeof name];
+            } else {
+              // 다중 선택
+              if (newValue.length < minSelection) {
+                setError(name, {
+                  type: 'manual',
+                  message: `최소 ${minSelection}개 이상 선택해야 합니다.`,
+                });
+              } else if (newValue.length > maxSelection) {
+                setError(name, {
+                  type: 'manual',
+                  message: `최대 ${maxSelection}개까지 선택 가능 합니다.`,
+                });
+                return;
+              }
+              selectedValue = newValue;
             }
 
-            setValue(name, newValue, { shouldValidate: true });
+            setValue(name, selectedValue, { shouldValidate: true });
           };
 
           return (

--- a/src/components/register/toggle-field.tsx
+++ b/src/components/register/toggle-field.tsx
@@ -86,7 +86,7 @@ const ToggleField = <T extends FieldValues>({
                 value={value}
                 onChange={handleValueChange}
                 ariaLabel={`${label} 옵션`}
-                variant={'black'}
+                variant={'primary'}
               />
               {error && (
                 <p className="text-red-500 text-sm mt-2">{error.message}</p>

--- a/src/constants/create-group.ts
+++ b/src/constants/create-group.ts
@@ -1,0 +1,42 @@
+interface Options {
+  value: string;
+}
+
+export const jobOptions: Options[] = [
+  { value: '상관없음' },
+  { value: '기획 & 운영' },
+  { value: '개발자 & 엔지니어' },
+  { value: '스타트업 & 창업자' },
+  { value: '비즈니스 & 마케팅' },
+  { value: '디자이너' },
+  { value: '기타 전문직' },
+];
+
+export const interestOptions: Options[] = [
+  { value: '상관없음' },
+  { value: '소프트웨어 개발' },
+  { value: '데이터&AI' },
+  { value: '클라우드&인프라' },
+  { value: '엔터테인먼트&미디어' },
+  { value: '보안&블록체인' },
+  { value: '핀테크&금융' },
+  { value: '헬스케어&바이오' },
+  { value: '스타트업&창업' },
+];
+
+export const experienceOptions: Options[] = [
+  { value: '학생' },
+  { value: '신입(1년 이하)' },
+  { value: '주니어(1~3년)' },
+  { value: '미드 레벨(4~7년)' },
+  { value: '창업자/임원' },
+];
+
+export const purposeOptions: Options[] = [
+  { value: '상관없음' },
+  { value: '멘토링 & 커리어 성장' },
+  { value: '비즈니스 파트너십' },
+  { value: '협업 & 프로젝트' },
+  { value: '채용 & 구인' },
+  { value: '기술 & 코드 리뷰' },
+];

--- a/src/utils/get-top-nav-type.ts
+++ b/src/utils/get-top-nav-type.ts
@@ -1,5 +1,6 @@
 const routes = [
   { path: '/home', type: 'quick-network' },
+  { path: '/create-group', type: 'default', title: '그룹 만들기' },
   { path: '/chat', type: 'chat-room' },
   { path: '/notifications', type: 'default', title: '알림' },
   { path: '/mypage', type: 'default', title: '마이페이지' },


### PR DESCRIPTION
## 📌 관련 이슈

> - #76 

## 📑 작업 내용

- 기존 register/interest 페이지에 있던 toggle 폼을 toggle field 컴포넌트로 분리
- toggle field 컴포넌트에 단일 선택 기능 추가
- top-nav에 뒤로가기 버튼 추가
- 퍼블리싱 



## 🖥️ (Optional) 참고자료
<img width="319" alt="스크린샷 2025-03-18 오전 4 21 59" src="https://github.com/user-attachments/assets/dc22c455-1f53-44a1-9bae-7a70e3105bd4" />
<img width="312" alt="스크린샷 2025-03-18 오전 4 22 05" src="https://github.com/user-attachments/assets/db6bcb7e-094f-40b0-95d8-d46e2260eb3d" />


