### PR TITLE
Feat: 유저 직군에 맞는 이미지 적용 

### DIFF
--- a/src/components/card/match-card.tsx
+++ b/src/components/card/match-card.tsx
@@ -62,9 +62,10 @@ const MatchCard = ({
         >
           <StatusForGroup variants="available" />
           <div className="flex relative flex-row-reverse">
-            <DefaultProfile size="xs" className="relative" />
+            <DefaultProfile size="xs" className="relative" jobValue={userData.jobValue}/>
             {members.map((user, index) => (
               <DefaultProfile
+                jobValue={userData.jobValue}
                 key={user.id}
                 size="xs"
                 className={`absolute ${positionClass[index] || 'right-16 z-40'}`}

--- a/src/components/card/match-card.tsx
+++ b/src/components/card/match-card.tsx
@@ -62,7 +62,11 @@ const MatchCard = ({
         >
           <StatusForGroup variants="available" />
           <div className="flex relative flex-row-reverse">
-            <DefaultProfile size="xs" className="relative" jobValue={userData.jobValue}/>
+            <DefaultProfile
+              size="xs"
+              className="relative"
+              jobValue={userData.jobValue}
+            />
             {members.map((user, index) => (
               <DefaultProfile
                 jobValue={userData.jobValue}

--- a/src/components/common/default-profile.tsx
+++ b/src/components/common/default-profile.tsx
@@ -9,25 +9,35 @@ import MonkeyIcon from '../common/quick-network/welcome-icon//monkey';
 import OtterIcon from '../common/quick-network/welcome-icon/otter';
 import QuokkaIcon from '../common/quick-network/welcome-icon/quokka';
 import RabbitIcon from '../common/quick-network/welcome-icon/rabbit';
-import SnailIcon from '../common/quick-network/welcome-icon/snail';
 import SnowmanIcon from '../common/quick-network/welcome-icon/snowman';
 import WhaleIcon from '../common/quick-network/welcome-icon/whale';
-import { useEffect, useState } from 'react';
 
-const icons = [
-  BirdIcon,
-  CatIcon,
-  DogIcon,
-  JellyFishIcon,
-  KoalaIcon,
-  MonkeyIcon,
-  OtterIcon,
-  QuokkaIcon,
-  RabbitIcon,
-  SnailIcon,
-  SnowmanIcon,
-  WhaleIcon,
-];
+const valueIconMap: Record<string, React.FC<React.SVGProps<SVGSVGElement>>> = {
+  '프론트엔드 개발자': MonkeyIcon,
+  '백엔드 개발자': MonkeyIcon,
+  '풀스택 개발자': MonkeyIcon,
+  '모바일 개발자': MonkeyIcon,
+  'AI 엔지니어': SnowmanIcon,
+  '데이터 엔지니어': SnowmanIcon,
+  '클라우드 엔지니어': WhaleIcon,
+  마케팅: KoalaIcon,
+  세일즈: CatIcon,
+  투자유치: CatIcon,
+  '파트너십 기획': CatIcon,
+  '콘텐츠 운영': DogIcon,
+  'UX/UI 디자이너': JellyFishIcon,
+  '브랜드 디자이너': JellyFishIcon,
+  '프로덕트 디자이너': JellyFishIcon,
+  '프로덕트 매니저 (PM)': OtterIcon,
+  '프로덕트 오너 (PO)': OtterIcon,
+  '서비스 기획자': OtterIcon,
+  '초기 스타트업 창업자': QuokkaIcon,
+  투자자: RabbitIcon,
+  액셀러레이터: RabbitIcon,
+  연구원: BirdIcon,
+  교육자: BirdIcon,
+  컨설턴트: BirdIcon,
+};
 
 const colors = [
   '#30B6FD', // Blue
@@ -61,38 +71,26 @@ const defaultProfileVariants = cva(
   },
 );
 
-const RandomIcon = () => {
-  const [SelectedIcon, setSelectedIcon] = useState<React.FC<
-    React.SVGProps<SVGSVGElement>
-  > | null>(null);
-  const [color, setColor] = useState<string>('#000');
-
-  useEffect(() => {
-    const icon = icons[Math.floor(Math.random() * icons.length)];
-    const color = colors[Math.floor(Math.random() * colors.length)];
-    setSelectedIcon(() => icon);
-    setColor(color);
-  }, []);
-
-  if (!SelectedIcon) return null;
-
-  return (
-    <SelectedIcon
-      className="w-full h-full fill-current"
-      style={{ fill: color, color }}
-    />
-  );
-};
 interface DefaultProfileProps
   extends React.HTMLAttributes<HTMLDivElement>,
     VariantProps<typeof defaultProfileVariants> {
-  imgSrc?: string;
+  jobValue: string | undefined;
 }
 
-const DefaultProfile = ({ size, className }: DefaultProfileProps) => {
+const DefaultProfile = ({
+  size,
+  className,
+  jobValue = '',
+}: DefaultProfileProps) => {
+  const Icon = valueIconMap[jobValue.trim()] ?? WhaleIcon;
+  const color = colors[Math.floor(Math.random() * colors.length)];
+
   return (
     <div className={cn(defaultProfileVariants({ size }), className)}>
-      <RandomIcon />
+      <Icon
+        className="w-full h-full fill-current"
+        style={{ fill: color, color }}
+      />
     </div>
   );
 };

--- a/src/components/common/default-profile.tsx
+++ b/src/components/common/default-profile.tsx
@@ -1,4 +1,4 @@
-'use client'
+'use client';
 import { cva, VariantProps } from 'class-variance-authority';
 import { cn } from '~/utils/cn';
 import BirdIcon from '../common/quick-network/welcome-icon/bird';

--- a/src/components/common/default-profile.tsx
+++ b/src/components/common/default-profile.tsx
@@ -1,3 +1,4 @@
+'use client'
 import { cva, VariantProps } from 'class-variance-authority';
 import { cn } from '~/utils/cn';
 import BirdIcon from '../common/quick-network/welcome-icon/bird';
@@ -11,6 +12,7 @@ import QuokkaIcon from '../common/quick-network/welcome-icon/quokka';
 import RabbitIcon from '../common/quick-network/welcome-icon/rabbit';
 import SnowmanIcon from '../common/quick-network/welcome-icon/snowman';
 import WhaleIcon from '../common/quick-network/welcome-icon/whale';
+import { useEffect, useState } from 'react';
 
 const valueIconMap: Record<string, React.FC<React.SVGProps<SVGSVGElement>>> = {
   '프론트엔드 개발자': MonkeyIcon,
@@ -83,8 +85,13 @@ const DefaultProfile = ({
   jobValue = '',
 }: DefaultProfileProps) => {
   const Icon = valueIconMap[jobValue.trim()] ?? WhaleIcon;
-  const color = colors[Math.floor(Math.random() * colors.length)];
+  const [color, setColor] = useState<string>(''); // 초기에는 빈 값
+  useEffect(() => {
+    const randomColor = colors[Math.floor(Math.random() * colors.length)];
+    setColor(randomColor);
+  }, []);
 
+  if (!color) return null;
   return (
     <div className={cn(defaultProfileVariants({ size }), className)}>
       <Icon

--- a/src/components/common/profile-important.tsx
+++ b/src/components/common/profile-important.tsx
@@ -44,6 +44,7 @@ const ProfileImportant = ({
       <DefaultProfile
         size="profileChat"
         className={isTopAligned ? 'mt-[-12px]' : ''}
+        jobValue={userData?.jobValue}
       />
 
       {/* 텍스트 영역 */}


### PR DESCRIPTION
## 📌 관련 이슈

> 관련된 이슈를 태그해주세요 ex) #130 

## 📑 작업 내용

- 유저 직군에 알맞는 이미지가 프로필 이미지로 설정됩니다. 

## 🖥️ (Optional) 참고자료
<img width="689" alt="image" src="https://github.com/user-attachments/assets/24ae9a8a-07ee-4870-b89a-126b26ca46fa" />

